### PR TITLE
Fixed a non idempotent Test

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/DelegatingFilterProxyRegistrationBeanTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/DelegatingFilterProxyRegistrationBeanTests.java
@@ -83,6 +83,7 @@ class DelegatingFilterProxyRegistrationBeanTests extends AbstractFilterRegistrat
 		assertThat(mockFilterInitialized.get()).isNull();
 		filter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(), new MockFilterChain());
 		assertThat(mockFilterInitialized.get()).isTrue();
+		mockFilterInitialized.remove();
 	}
 
 	@Test


### PR DESCRIPTION
<!--
Thanks for raising a Spring Boot issue. Please take the time to review the following
categories as some of them do not apply here.

🙅 "Please DO NOT Raise an Issue" Cases
- Question
STOP!! Please ask questions about how to use something, or to understand why something isn't
working as you expect it to, on Stack Overflow using the spring-boot tag.
- Security Vulnerability
STOP!! Please don't raise security vulnerabilities here. Head over to https://spring.io/security-policy to learn how to disclose them responsibly.
- Managed Dependency Upgrade
You DO NOT need to raise an issue for a managed dependency version upgrade as there's a semi-automatic process for checking managed dependencies for new versions before a release. BUT pull requests for upgrades that are more involved than just a version property change are still most welcome.
- With an Immediate Pull Request
An issue will be closed as a duplicate of the immediate pull request, so you don't have to raise an issue if you plan to create a pull request immediately.

🐞 Bug report (please don't include this emoji/text, just add your details)
Please provide details of the problem, including the version of Spring Boot that you
are using. If possible, please provide a test case or sample application that reproduces
the problem. This makes it much easier for us to diagnose the problem and to verify that
we have fixed it.

🎁 Enhancement (please don't include this emoji/text, just add your details)
Please start by describing the problem that you are trying to solve. There may already
be a solution, or there may be a way to solve it that you hadn't considered.


TIP: You can always edit your issue if it isn't formatted correctly.
     See https://guides.github.com/features/mastering-markdown 
-->

### Issue
The test `org.springframework.boot.web.servlet.DelegatingFilterProxyRegistrationBeanTests.initShouldNotCauseEarlyInitialization` is not idempotent because it pollutes a shared state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

This might fail future tests that share the same state similar to https://github.com/spring-projects/spring-boot/issues/38363

### Detail
AssertionFailedError log when `initShouldNotCauseEarlyInitialization` was run twice in the same JVM:
```
org.junit.ComparisonFailure: 
Expected :null
Actual   :true

// Failed at this line:
assertThat(mockFilterInitialized.get()).isNull();

```

The root cause is that in each of the test runs, the `ThreadLocal<Boolean> mockFilterInitialized` is set, which is not removed when the test exits. Therefore, when the assertion is hit during the second test run, `mockFilterInitialized` is still set(not null), leading to the assertion error.

The suggested fix is to remove the `mockFilterInitialized` when each test exits.
```
assertThat(mockFilterInitialized.get()).isNull();
filter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(), new MockFilterChain());
assertThat(mockFilterInitialized.get()).isTrue();
mockFilterInitialized.remove();
```
The proposed fix resolves the issue of state pollution proactively before it causes other tests to fail.